### PR TITLE
exec: probe plugin that runs command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,15 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.38"
 clap = "3.0.0-beta.2"
 crossbeam-channel = "0.5.0"
 ctrlc = "3.1.7"
 job_scheduler = "1.2.1"
 log = "0.4.11"
+reqwest = { version = "0.11.0", features = ["blocking"] }
 serde = "1.0.118"
 serde_derive = "1.0.118"
 simple_logger = "1.11.0"
+slack-hook = "0.8.0"
 toml = "0.5.8"

--- a/otto.toml.example
+++ b/otto.toml.example
@@ -1,0 +1,13 @@
+schedule = "0/5 * * * * *"
+
+[[probes.exec]]
+cmd = "./test.sh"
+
+[[probes.http]]
+schedule = "0/10 * * * * *"
+url = "https://google.ca"
+method = "get"
+expected_code = 200
+
+[[alerts.slack]]
+webhook_url = "https://hooks.slack.com/services/abc/123/45z"

--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -1,31 +1,25 @@
+use super::probes::Notification;
+use super::register_plugins;
+use super::Config;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
-use super::Config;
-use super::plugin_from;
 
-pub mod slack;
 pub mod gmail;
+pub mod slack;
 
 #[derive(Debug, Deserialize)]
 pub struct Alerts {
-    pub slack: Option<slack::Slack>,
-    pub gmail: Option<gmail::Gmail>,
+    pub slack: Option<Vec<slack::Slack>>,
+    pub gmail: Option<Vec<gmail::Gmail>>,
 }
 
-pub fn register_from(config: &Config) -> HashMap<String, Box<dyn Alert>> {
+pub fn register_from(config: &Config) -> HashMap<String, Vec<Box<dyn Alert>>> {
     let mut alerts = HashMap::new();
-    let mut plugin: Box<dyn Alert>;
-    match plugin_from!(config.alerts, slack) {
-        Some(plg) => { plugin = Box::new(plg.clone()); alerts.insert("slack".to_string(), plugin); println!(""); },
-        None => println!(""),
-    };
-    match plugin_from!(config.alerts, gmail) {
-        Some(plg) => { plugin = Box::new(plg.clone()); alerts.insert("gmail".to_string(), plugin); println!(""); },
-        None => println!(""),
-    };
+    register_plugins!(Alert => config.alerts.slack);
+    register_plugins!(Alert => config.alerts.gmail);
     alerts
 }
 
 pub trait Alert {
-    fn notify(&self);
+    fn notify(&self, notif: &Notification);
 }

--- a/src/alerts/gmail.rs
+++ b/src/alerts/gmail.rs
@@ -1,4 +1,5 @@
 use super::Alert;
+use super::Notification;
 use serde_derive::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -11,7 +12,8 @@ pub struct Gmail {
 }
 
 impl Alert for Gmail {
-    fn notify(&self) {
+    fn notify(&self, notif: &Notification) {
         println!("ALERT -> Gmail");
+        println!("{:?}", notif);
     }
 }

--- a/src/alerts/slack.rs
+++ b/src/alerts/slack.rs
@@ -1,13 +1,45 @@
 use super::Alert;
+use super::Notification;
 use serde_derive::Deserialize;
+use slack_hook::{PayloadBuilder, Slack as SlackHook};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Slack {
-    pub api_key: String,
+    pub webhook_url: String,
 }
 
 impl Alert for Slack {
-    fn notify(&self) {
-        println!("ALERT -> SLACK");
+    fn notify(&self, notif: &Notification) {
+        log::info!("ALERT -> SLACK");
+        log::debug!("NOTIFICATION: {:?}", notif);
+
+        let url: &str = &self.webhook_url;
+        let slack = match SlackHook::new(url) {
+            Ok(slack) => slack,
+            Err(err) => {
+                log::error!("failed to create slack webhook with url {}: {}", url, err);
+                return;
+            }
+        };
+        let payload = match PayloadBuilder::new()
+            .text(format!(
+                "Alert received from [*{}*] plugin:\n> {}\n```{}```",
+                notif.from, notif.check, notif.result
+            ))
+            .username("Otto")
+            .icon_emoji(":robot_face:")
+            .build()
+        {
+            Ok(payload) => payload,
+            Err(err) => {
+                log::error!("failed to build slack webhook payload: {}", err);
+                return;
+            }
+        };
+
+        match slack.send(&payload) {
+            Ok(()) => return,
+            Err(err) => log::error!("failed to post message to slack webhook url: {}", err),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,11 @@
+use super::alerts::Alerts;
+use super::probes::Probes;
+use serde_derive::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub schedule: String,
+    pub log_level: String,
+    pub probes: Option<Probes>,
+    pub alerts: Option<Alerts>,
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,14 +5,34 @@ macro_rules! plugin_from {
             Some(cfg) => match cfg.$plugin.as_ref() {
                 Some(plg) => Some(plg),
                 None => {
-                    log::info!("plugin {} is not defined in config file", stringify!($plugin));
+                    log::info!(
+                        "plugin {} is not defined in config file",
+                        stringify!($plugin)
+                    );
                     None
-                },
+                }
             },
             None => {
                 log::warn!("no plugins defined for {} in config file", stringify!($cfg));
                 None
-            },
+            }
         }
+    }};
+}
+
+#[macro_export]
+macro_rules! register_plugins {
+    ($type:ident => $config:ident.$plugins:ident.$plugin:ident) => {{
+        match super::plugin_from!($config.$plugins, $plugin) {
+            Some(plgs) => {
+                let mut plugins: Vec<Box<dyn $type>> = Vec::new();
+                for plg in plgs.iter() {
+                    plugins.push(Box::new(plg.clone()));
+                }
+                let plugin_group = stringify!("{}", $plugin).to_string();
+                $plugins.insert(plugin_group, plugins);
+            }
+            None => println!(""),
+        };
     }};
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,20 @@
 mod alerts;
+mod config;
 mod probes;
 
 #[macro_use]
 mod macros;
 
+use anyhow::{Context, Result};
 use clap::Clap;
+use config::Config;
 use crossbeam_channel::{bounded, select, tick, Receiver};
 use job_scheduler::{Job, JobScheduler};
-use serde_derive::Deserialize;
+use log::LevelFilter;
 use simple_logger::SimpleLogger;
 use std::error::Error;
-use std::fs;
+use std::str::FromStr;
 use std::time::Duration;
-
-#[derive(Debug, Deserialize)]
-pub struct Config {
-    schedule: String,
-    probes: Option<probes::Probes>,
-    alerts: Option<alerts::Alerts>,
-}
 
 #[derive(Clap)]
 #[clap(version = "1.0", author = "Rollie Ma <rollie@rollie.dev>")]
@@ -27,22 +23,18 @@ struct Opts {
     config: String,
 }
 
-fn ctrl_channel() -> Result<Receiver<()>, ctrlc::Error> {
-    let (sender, receiver) = bounded(100);
-    ctrlc::set_handler(move || {
-        let _ = sender.send(());
-    })?;
-
-    Ok(receiver)
-}
-
 fn main() -> Result<(), Box<dyn Error>> {
-    SimpleLogger::new().init()?;
-
     let opts: Opts = Opts::parse();
 
-    let buffer: String = fs::read_to_string(opts.config)?;
-    let config: Config = toml::from_str(&buffer)?;
+    let config_file: &str = &opts.config;
+    let buffer: String = std::fs::read_to_string(config_file)
+        .with_context(|| format!("could not read file `{}`", config_file))?;
+    let config: Config = toml::from_str(&buffer)
+        .with_context(|| format!("could not parse toml config file `{}`", config_file))?;
+
+    SimpleLogger::new()
+        .with_level(LevelFilter::from_str(&config.log_level)?)
+        .init()?;
 
     let probes = probes::register_from(&config);
     let alerts = alerts::register_from(&config);
@@ -50,15 +42,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut sched = JobScheduler::new();
     let global = config.schedule;
 
-    for (name, plugin) in probes.iter() {
-        log::info!("starting probe plugin: {}", name);
+    for (name, plugins) in probes.iter() {
+        log::info!("starting probe plugins: {} x {}", plugins.len(), name);
         let alerts = &alerts;
-        sched.add(Job::new(
-            plugin.schedule(&global).parse().unwrap(),
-            move || {
-                plugin.observe(alerts);
-            },
-        ));
+        for plugin in plugins.iter() {
+            sched.add(Job::new(
+                plugin.schedule(&global).parse().unwrap(),
+                move || {
+                    plugin.observe(alerts);
+                },
+            ));
+        }
     }
 
     let ctrl_c_events = ctrl_channel()?;
@@ -77,4 +71,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+fn ctrl_channel() -> Result<Receiver<()>, ctrlc::Error> {
+    let (sender, receiver) = bounded(100);
+    ctrlc::set_handler(move || {
+        let _ = sender.send(());
+    })?;
+
+    Ok(receiver)
 }

--- a/src/probes/exec.rs
+++ b/src/probes/exec.rs
@@ -1,7 +1,9 @@
 use super::Alert;
+use super::Notification;
 use super::Probe;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
+use std::process::Command;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Exec {
@@ -11,10 +13,36 @@ pub struct Exec {
 }
 
 impl Probe for Exec {
-    fn observe(&self, alerts: &HashMap<String, Box<dyn Alert>>) {
-        println!("PROBE -> EXEC");
-        self.notify(alerts);
+    fn observe(&self, alerts: &HashMap<String, Vec<Box<dyn Alert>>>) {
+        log::info!("executing command {:?} with args {:?}", self.cmd, self.args);
+
+        let mut cmd = Command::new(&self.cmd);
+        if let Some(args) = &self.args {
+            cmd.args(args);
+        }
+        let output = match cmd.output() {
+            Ok(output) => output,
+            Err(err) => {
+                log::error!("failed to execute command {}", err);
+                return;
+            }
+        };
+        if !output.status.success() {
+            self.notify(
+                alerts,
+                Notification {
+                    from: "exec".to_owned(),
+                    check: format!("command `{}` with args `{:?}`", self.cmd, self.args),
+                    result: format!(
+                        "{}: {}",
+                        output.status,
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                },
+            );
+        }
     }
+
     fn local_schedule(&self) -> Option<String> {
         self.schedule.to_owned()
     }

--- a/src/probes/http.rs
+++ b/src/probes/http.rs
@@ -1,4 +1,5 @@
 use super::Alert;
+use super::Notification;
 use super::Probe;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
@@ -6,15 +7,53 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize)]
 pub struct HTTP {
     schedule: Option<String>,
-    https: bool,
     url: String,
+    method: String,
+    expected_code: u16,
 }
 
 impl Probe for HTTP {
-    fn observe(&self, alerts: &HashMap<String, Box<dyn Alert>>) {
-        println!("PROBE -> HTTP");
-        self.notify(alerts);
+    fn observe(&self, alerts: &HashMap<String, Vec<Box<dyn Alert>>>) {
+        log::info!(
+            "opening url {} with {} request with expected status code {}",
+            self.url,
+            self.method,
+            self.expected_code
+        );
+
+        let func = match &self.method as &str {
+            "get" => reqwest::blocking::get,
+            _ => {
+                log::error!("unknown request method: {}", self.method);
+                return;
+            }
+        };
+        let resp = match func(&self.url) {
+            Ok(resp) => resp,
+            Err(err) => {
+                log::error!("failed to {} request {}: {}", self.method, self.url, err);
+                return;
+            }
+        };
+        if resp.status().as_u16() != self.expected_code {
+            self.notify(
+                alerts,
+                Notification {
+                    from: "http".to_owned(),
+                    check: format!(
+                        "http {} request to url {} with expected status code {}",
+                        self.method, self.url, self.expected_code
+                    ),
+                    result: format!(
+                        "expected status code is {} and actual code is {}",
+                        self.expected_code,
+                        resp.status().as_u16()
+                    ),
+                },
+            );
+        }
     }
+
     fn local_schedule(&self) -> Option<String> {
         self.schedule.to_owned()
     }


### PR DESCRIPTION
this commit also includes
- http probe plugin
- slack alert plugin
- move config struct to a separate file/module
- in config, probes and alerts now accepts arrays of tables, so each
  plugin type can have multiple plugins, for example, probing 2 or more
  urls