### PR TITLE
probes: add gauge metrics to indicate if plugin is triggered

### DIFF
--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -1,6 +1,4 @@
-use super::probes::Notification;
-use super::register_plugins;
-use super::Config;
+use super::{probes::Notification, register_plugins, Config};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_derive::Deserialize;

--- a/src/alerts/email.rs
+++ b/src/alerts/email.rs
@@ -2,9 +2,11 @@ use super::{Alert, Notification};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use lazy_static::lazy_static;
-use lettre::message::{header, Mailbox, MultiPart, SinglePart};
-use lettre::transport::smtp::authentication::Credentials;
-use lettre::{Message, SmtpTransport, Transport};
+use lettre::{
+    message::{header, Mailbox, MultiPart, SinglePart},
+    transport::smtp::authentication::Credentials,
+    Message, SmtpTransport, Transport,
+};
 use prometheus::{register_counter_vec, CounterVec};
 use serde_derive::Deserialize;
 

--- a/src/alerts/slack.rs
+++ b/src/alerts/slack.rs
@@ -1,5 +1,4 @@
-use super::Alert;
-use super::Notification;
+use super::{Alert, Notification};
 use anyhow::Result;
 use async_trait::async_trait;
 use lazy_static::lazy_static;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
-use super::alerts::Alerts;
-use super::probes::Probes;
+use super::{alerts::Alerts, probes::Probes};
 use serde_derive::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/probes.rs
+++ b/src/probes.rs
@@ -1,6 +1,4 @@
-use super::alerts::Alert;
-use super::register_plugins;
-use super::Config;
+use super::{alerts::Alert, register_plugins, Config};
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;

--- a/src/probes/atom.rs
+++ b/src/probes/atom.rs
@@ -1,12 +1,10 @@
-use super::Alert;
-use super::Notification;
-use super::Probe;
+use super::{Alert, Notification, Probe};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use atom_syndication::Feed;
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
-use prometheus::{register_counter_vec, CounterVec};
+use prometheus::{register_counter_vec, register_gauge_vec, CounterVec, GaugeVec};
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 
@@ -32,6 +30,12 @@ lazy_static! {
         &["plugin", "feed_url"]
     )
     .unwrap();
+    static ref TRIGGERED: GaugeVec = register_gauge_vec!(
+        "probe_atom_triggered",
+        "Atom probe plugin triggered",
+        &["plugin", "feed_url"]
+    )
+    .unwrap();
 }
 
 #[async_trait]
@@ -46,6 +50,7 @@ impl Probe for Atom {
             .with_label_values(&["probe.atom", &self.feed_url])
             .inc();
 
+        let mut triggered = 0;
         let content = reqwest::get(&self.feed_url).await?.bytes().await?;
         let feed = Feed::read_from(&content[..])?;
 
@@ -97,8 +102,12 @@ impl Probe for Atom {
                 TRIGGERED_TOTAL
                     .with_label_values(&["probe.atom", &self.feed_url])
                     .inc();
+                triggered = 1;
             }
         }
+        TRIGGERED
+            .with_label_values(&["probe.atom", &self.feed_url])
+            .set(triggered as f64);
         Ok(())
     }
 }


### PR DESCRIPTION
```
# HELP probe_atom_runs_total run counter for Atom probe plugin
# TYPE probe_atom_runs_total counter
probe_atom_runs_total{feed_url="https://feeds.feedburner.com/herokustatus",plugin="probe.atom"} 1
probe_atom_runs_total{feed_url="https://www.cloudflarestatus.com/history.atom",plugin="probe.atom"} 1
# HELP probe_atom_triggered Atom probe plugin triggered
# TYPE probe_atom_triggered gauge
probe_atom_triggered{feed_url="https://feeds.feedburner.com/herokustatus",plugin="probe.atom"} 0
probe_atom_triggered{feed_url="https://www.cloudflarestatus.com/history.atom",plugin="probe.atom"} 0
# HELP probe_exec_runs_total run counter for exec probe plugin
# TYPE probe_exec_runs_total counter
probe_exec_runs_total{cmd="./examples/check_ssl_cert.sh",plugin="probe.exec"} 1
# HELP probe_exec_triggered Exec probe plugin triggered
# TYPE probe_exec_triggered gauge
probe_exec_triggered{cmd="./examples/check_ssl_cert.sh",plugin="probe.exec"} 0
# HELP probe_http_runs_total run counter for HTTP probe plugin
# TYPE probe_http_runs_total counter
probe_http_runs_total{method="get",plugin="probe.http",url="https://google.ca"} 7
probe_http_runs_total{method="post",plugin="probe.http",url="https://httpbin.org/post"} 7
# HELP probe_http_triggered HTTP probe plugin triggered
# TYPE probe_http_triggered gauge
probe_http_triggered{method="get",plugin="probe.http",url="https://google.ca"} 0
probe_http_triggered{method="post",plugin="probe.http",url="https://httpbin.org/post"} 0
# HELP probe_rss_runs_total run counter for RSS probe plugin
# TYPE probe_rss_runs_total counter
probe_rss_runs_total{feed_url="https://www.githubstatus.com/history.rss",plugin="probe.rss"} 1
# HELP probe_rss_triggered RSS probe plugin triggered
# TYPE probe_rss_triggered gauge
probe_rss_triggered{feed_url="https://www.githubstatus.com/history.rss",plugin="probe.rss"} 0
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.12
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1048576
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 15
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 15851520
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1614118173.44
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 783261696
```