### PR TITLE
make: new target that generates coverage report with tarpaulin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,15 @@ lint:
 test:
 	cargo test
 
+.PHONY: cover
+cover:
+	docker run \
+		--security-opt seccomp=unconfined \
+		-v ${PWD}:/volume \
+		xd009642/tarpaulin \
+		cargo tarpaulin --out Html --output-dir ./target
+	open target/tarpaulin-report.html
+
 .PHONY: cross
 cross: build
 	docker build -t $(APP)/cross -f cross.Dockerfile .

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,8 @@ A complete config file is consisted of global configs, probe plugins and alert p
 schedule = "0 * * * * *"
 
 [prometheus]
-listen = "127.0.0.1:9999"
+# Have prometheus metrics exposed at http://0.0.0.0:9999/metrics
+listen = "0.0.0.0:9999"
 path = "metrics"
 ```
 


### PR DESCRIPTION
Output from `make cover`:

```
Mar 14 08:22:41.355  INFO cargo_tarpaulin::report: Coverage Results:
|| Tested/Total Lines:
|| src/alerts/email.rs: 4/46 +0%
|| src/alerts/slack.rs: 4/34 +0%
|| src/alerts/webhook.rs: 4/27 +0%
|| src/alerts.rs: 14/20 +0%
|| src/main.rs: 0/27 +0%
|| src/probes/atom.rs: 1/55 +0%
|| src/probes/exec.rs: 1/48 +0%
|| src/probes/http.rs: 1/58 +0%
|| src/probes/rss.rs: 1/53 +0%
|| src/probes.rs: 24/72 +0%
|| src/web.rs: 0/23 +0%
||
11.66% coverage, 54/463 lines covered, +0% change in coverage
```

Showing HTML coveragte report from web browser:

![Screen Shot 2021-03-14 at 12 38 00 AM](https://user-images.githubusercontent.com/965430/111062436-944f9300-845d-11eb-838d-8aec935d33ba.png)